### PR TITLE
Bump up version to v0.2.3

### DIFF
--- a/lib/capng/version.rb
+++ b/lib/capng/version.rb
@@ -1,3 +1,3 @@
 class CapNG
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
Although it might be better to bump up minor version v0.3 since CI for Ruby 2.4 was dropped at 9735377cd7c6104f6046e1413f1e99c38f955ffb I don't do it for now because there is no obvious reason.

There is no meaningful change from v0.2.2 except d028819b5cc958f3322e26ba75f7ae3b90067868 in #11 and Ruby dependency in capng_c.gemspec isn't changed yet too. d028819b5cc958f3322e26ba75f7ae3b90067868 still keeps backward compatibility.