### PR TITLE
Add check whether pkg-config was installed

### DIFF
--- a/ext/capng/extconf.rb
+++ b/ext/capng/extconf.rb
@@ -20,6 +20,10 @@ includedir = RbConfig::CONFIG["includedir"]
 
 dir_config("capng", includedir, libdir)
 
+unless find_executable("pkg-config")
+  raise "Require pkg-config due to install capng_c gem. Please install pkg-config."
+end
+
 pkg_config("libcap-ng")
 $CFLAGS << " -Wall -std=c99 -fPIC "
 # $CFLAGS << " -g -O0"


### PR DESCRIPTION
We can build and install capng_c even if pkg-config is not installed.
However, it does not work because it does not link to libcap-ng properly.

Actually, the install log indicates that libcap-ng can't be found.
Ref. `checking for pkg-config for libcap-ng... not found` line with following install log. 

So, this patch will abort install process if pkg-config is not installed.

```
# rake
mkdir -p tmp/x86_64-linux/capng/3.4.2
cd tmp/x86_64-linux/capng/3.4.2
/root/.rbenv/versions/3.4.2/bin/ruby -I. ../../../../ext/capng/extconf.rb
checking for pkg-config for libcap-ng... not found
checking for CAPNG_SELECT_AMBIENT in cap-ng.h... no
checking for CAPNG_SELECT_ALL in cap-ng.h... no
checking for CAPNG_AMBIENT in cap-ng.h... no
checking for CAPNG_INIT_SUPP_GRP in cap-ng.h... yes
checking for rb_sym2str() in ruby.h... yes
checking for rb_io_descriptor() in ruby.h... yes
checking for capng_get_caps_fd() in cap-ng.h... no
creating Makefile
cd -
cd tmp/x86_64-linux/capng/3.4.2
/usr/bin/gmake
compiling ../../../../ext/capng/capability.c
compiling ../../../../ext/capng/capability_info.c
compiling ../../../../ext/capng/capng.c
compiling ../../../../ext/capng/enum-action.c
compiling ../../../../ext/capng/enum-flags.c
compiling ../../../../ext/capng/enum-result.c
compiling ../../../../ext/capng/enum-select.c
compiling ../../../../ext/capng/enum-type.c
compiling ../../../../ext/capng/enum.c
compiling ../../../../ext/capng/print.c
compiling ../../../../ext/capng/state.c
compiling ../../../../ext/capng/utils.c
linking shared-object capng/capng.so
cd -
mkdir -p tmp/x86_64-linux/stage/lib/capng
/usr/bin/gmake install sitearchdir=../../../../lib/capng sitelibdir=../../../../lib/capng target_prefix=
/usr/bin/install -c -m 0755 capng.so ../../../../lib/capng
cp tmp/x86_64-linux/capng/3.4.2/capng.so tmp/x86_64-linux/stage/lib/capng/capng.so
Loaded suite /root/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/rake_test_loader
Started
/root/.rbenv/versions/3.4.2/bin/ruby: symbol lookup error: /root/capng_c/lib/capng/capng.so: undefined symbol: capng_clear
rake aborted!
Command failed with status (127)
```