### PR TITLE
ci: update Debian platform to Bookworm

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -9,12 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - Debian GNU/Linux Buster amd64
+          - Debian GNU/Linux Bookworm amd64
           - Ubuntu Bionic amd64
           - Ubuntu Focal amd64
         include:
-          - label: Debian GNU/Linux Buster amd64
-            test-docker-image: debian:buster
+          - label: Debian GNU/Linux Bookworm amd64
+            test-docker-image: debian:bookworm
             test-script: ci/apt-test.sh
           - label: Ubuntu Bionic amd64
             test-docker-image: ubuntu:bionic


### PR DESCRIPTION
Because it seems that `apt update` fails on buster.
I think the cause of the error is that it has exceeded End of Life.
Ref. https://wiki.debian.org/DebianReleases

You can confirm the error with `docker run` command as following.

```
$ docker run \
  --rm \
  --tty \
  --volume ${PWD}:/capng \
  debian:buster \
  /capng/ci/apt-test.sh
+ export DEBIAN_FRONTEND=noninteractive
+ DEBIAN_FRONTEND=noninteractive
+ apt update
Ign:1 http://deb.debian.org/debian buster InRelease
Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
Ign:3 http://deb.debian.org/debian buster-updates InRelease
Err:4 http://deb.debian.org/debian buster Release
  404  Not Found [IP: 199.232.150.132 80]
Err:5 http://deb.debian.org/debian-security buster/updates Release
  404  Not Found [IP: 199.232.150.132 80]
Err:6 http://deb.debian.org/debian buster-updates Release
  404  Not Found [IP: 199.232.150.132 80]
Reading package lists... Done
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

So, this PR will update Debian platform to solve above error.