### PR TITLE
Rakefile: add "test:valgrind" task to detect memory leak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "irb"
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0') && RUBY_PLATFORM.include?('linux')
+  gem 'ruby_memcheck', '~> 3.0'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,11 @@ end
 
 CLEAN.include('lib/capng/capng.*')
 
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0') && RUBY_PLATFORM.include?('linux')
+  require 'ruby_memcheck'
+  namespace :test do
+    RubyMemcheck::TestTask.new(valgrind: :compile)
+  end
+end
+
 task :default => [:clobber, :compile, :test]


### PR DESCRIPTION
This PR introduces [ruby_memcheck](https://github.com/Shopify/ruby_memcheck)
to detect whether memory leak exists.

## Prepare
You might need to install [valgrind](https://valgrind.org/) at first to run the task.