### PR TITLE
Fix memory leak in CapNG::Print#{caps_text, caps_numeric}

### DIFF
--- a/ext/capng/print.c
+++ b/ext/capng/print.c
@@ -129,8 +129,11 @@ rb_capng_print_caps_text(VALUE self, VALUE rb_where_name_or_type,
       result = capng_print_caps_text(CAPNG_PRINT_BUFFER, capability_type);
   }
 
-  if (result)
-    return rb_str_new2(result);
+  if (result) {
+    VALUE obj = rb_str_new2(result);
+    free(result);
+    return obj;
+  }
   else
     return rb_str_new2("none");
 }
@@ -191,8 +194,11 @@ rb_capng_print_caps_numeric(VALUE self, VALUE rb_where_name_or_type,
       result = capng_print_caps_numeric(CAPNG_PRINT_BUFFER, select);
   }
 
-  if (result)
-    return rb_str_new2(result);
+  if (result) {
+    VALUE obj = rb_str_new2(result);
+    free(result);
+    return obj;
+  }
   else
     return rb_str_new2("none");
 }


### PR DESCRIPTION
Ref. https://github.com/fluent-plugins-nursery/capng_c/pull/15

`rb_str_new2()` is alias of `rb_str_new_cstr`.
https://github.com/ruby/ruby/blob/2bf88ac15dec2588caf543215036bcf2cb0b485a/include/ruby/internal/intern/string.h#L1675

rb_str_new_cstr() calls the function as following.
`rb_str_new_cstr()` -> `rb_str_new()` -> `str_new()` -> `str_enc_new()`
https://github.com/ruby/ruby/blob/2bf88ac15dec2588caf543215036bcf2cb0b485a/string.c#L1079

Finally, `str_enc_new()` just copy the given string.
```c
    if (ptr) {
        memcpy(RSTRING_PTR(str), ptr, len);
    }
```
https://github.com/ruby/ruby/blob/2bf88ac15dec2588caf543215036bcf2cb0b485a/string.c#L1039-L1040

So, we must release the memory area allocated by `capng_print_caps_text()` / `capng_print_caps_numeric()`.
Ruby's GC does not touch the area.