### PR TITLE
Fix use-after-free / double-free in CapNG::State#restore

### DIFF
--- a/ext/capng/state.c
+++ b/ext/capng/state.c
@@ -116,12 +116,15 @@ static VALUE
 rb_capng_state_restore(VALUE self)
 {
   struct CapNGState* capng_state;
-  void* state = NULL;
 
   TypedData_Get_Struct(self, struct CapNGState, &rb_capng_state_type, capng_state);
 
-  state = capng_state->state;
-  capng_restore_state(&state);
+  /* Pass the struct field itself so capng_restore_state() frees the block and
+   * resets our pointer to NULL. Passing a local copy (the previous behaviour)
+   * left capng_state->state dangling, causing a use-after-free / double-free on
+   * a second #restore. With the field NULLed, a repeated #restore is a safe
+   * no-op because libcap-ng ignores a NULL saved state. */
+  capng_restore_state(&capng_state->state);
 
   return Qnil;
 }

--- a/test/test_capng.rb
+++ b/test/test_capng.rb
@@ -117,6 +117,25 @@ class CapNGTest < ::Test::Unit::TestCase
         @state.restore
       end
     end
+
+    # Regression: a second #restore used to reuse a dangling pointer and crash
+    # with a double-free (SIGABRT). It must now be a safe no-op.
+    test "restore is safe to call twice" do
+      @state = CapNG::State.new
+      assert_nothing_raised do
+        @state.save
+        @state.restore
+        @state.restore
+      end
+    end
+
+    # Regression: restoring without a prior save must not crash.
+    test "restore without save is a no-op" do
+      @state = CapNG::State.new
+      assert_nothing_raised do
+        @state.restore
+      end
+    end
   end
 
   sub_test_case "Print" do


### PR DESCRIPTION
## Summary

Calling `CapNG::State#restore` twice triggers a use-after-free and a double-free, aborting the process with `SIGABRT` (`free(): double free detected`). This is a memory-safety bug reachable through the public API alone. This PR fixes how `#restore` hands the saved state to libcap-ng and adds regression tests.

## Problem

Before this change, `rb_capng_state_restore` copied the saved-state pointer into a local variable and then passed the address of that local to `capng_restore_state()`.

```c
state = capng_state->state;   /* copy the field value into a local */
capng_restore_state(&state);  /* pass the address of the local */
```

libcap-ng's `capng_restore_state(void **state)` frees the block and then resets the pointer whose address it was given back to `NULL`. Because the binding passed the address of a local, only the throwaway local was set to `NULL`, while the struct field `capng_state->state` was left dangling, still pointing at the freed block.

A second `#restore` reuses that dangling pointer, so `capng_restore_state()` performs a `memcpy` from the freed block (use-after-free read) and frees it again (double-free).

## Reproduction

Before the fix, the following crashes with `SIGABRT`.

```ruby
# requires libcap-ng headers + pkg-config
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'capng_c'
end

require 'capng'
s = CapNG::State.new
s.save
s.restore
s.restore   # before the fix: free(): double free detected -> SIGABRT
```

A Valgrind backtrace confirms the free happens inside `capng_restore_state`, driven by `rb_capng_state_restore` (`ext/capng/state.c`).

```
/usr/lib/libcap-ng.so.0(capng_restore_state+0xa2)
lib/capng/capng.so(rb_capng_state_restore+0x42) ext/capng/state.c
```

## Impact and compatibility

- The change touches only the `#restore` implementation in `ext/capng/state.c`; no public API signature or return value changes.
- The normal path (a single `restore` after `save`) behaves exactly as before.
- Verified with libcap-ng 0.9.3 and Ruby 4.0.5. The fix relies on the documented semantics of `capng_restore_state` (it NULLs the pointer at the address you pass and treats a `NULL` saved state as a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
