### PR TITLE
Guard the file-descriptor fallback against a NULL fptr

### DIFF
--- a/ext/capng/capng.c
+++ b/ext/capng/capng.c
@@ -75,7 +75,7 @@ capng_get_file_descriptor(VALUE rb_file)
 #else
   rb_io_t* fptr = NULL;
 
-  fptr = RFILE(rb_file)->fptr;
+  GetOpenFile(rb_file, fptr);
   return fptr->fd;
 #endif
 }

--- a/test/test_capng.rb
+++ b/test/test_capng.rb
@@ -232,6 +232,22 @@ class CapNGTest < ::Test::Unit::TestCase
                        @capability.from_name(@print.caps_text(:buffer, :effective))
         end
       end
+
+      test "caps_file on an uninitialized stream raises instead of crashing" do
+        assert_raise(IOError) do
+          @capng.caps_file(File.allocate)
+        end
+      end
+
+      test "caps_file on a closed stream raises instead of crashing" do
+        tf = Tempfile.create("capng-")
+        tf.close
+        assert_raise(IOError) do
+          @capng.caps_file(tf)
+        end
+      ensure
+        File.unlink(tf.path) if tf && File.exist?(tf.path)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

On Ruby versions that lack `rb_io_descriptor` (< 3.1), `caps_file` / `get_caps_file` / `apply_caps_file` can dereference a NULL pointer and crash when handed an uninitialized file object. This PR routes the fallback through `GetOpenFile`, which validates the stream before use, and adds regression tests. There is no behavior change on Ruby >= 3.1.

## Problem

`capng_get_file_descriptor()` has two implementations selected at build time. When `rb_io_descriptor` is available (Ruby >= 3.1) it is used and is safe. Otherwise the fallback reads the file descriptor directly:

```c
#else
  rb_io_t* fptr = NULL;

  fptr = RFILE(rb_file)->fptr;   /* fptr can be NULL */
  return fptr->fd;               /* NULL dereference */
#endif
```

`RFILE(rb_file)->fptr` is NULL for an uninitialized stream (for example `File.allocate`), so `fptr->fd` dereferences NULL and crashes the process. The public file methods reach this helper right after `Check_Type(rb_file, T_FILE)`, and an uninitialized `File` passes that type check, so the crash is reachable through the public API on the affected Ruby versions.

## Reproduction

On a Ruby build without `rb_io_descriptor` (< 3.1), the following crashes before the fix:

```ruby
require 'capng'

capng = CapNG.new
capng.caps_file(File.allocate)   # before the fix: NULL dereference -> crash
```

After the fix it raises `IOError: uninitialized stream`. A closed file (`f = File.open(path); f.close; capng.caps_file(f)`) likewise raises `IOError: closed stream` instead of crashing.

## Fix

Use `GetOpenFile`, which validates the stream and raises `IOError` on an uninitialized or closed stream instead of dereferencing NULL. This matches the safety the `rb_io_descriptor` path already provides.

```c
#else
  rb_io_t* fptr = NULL;

  GetOpenFile(rb_file, fptr);
  return fptr->fd;
#endif
```

## Impact and compatibility

- The change touches only the fallback branch of `capng_get_file_descriptor()` in `ext/capng/capng.c`; no public API signature or return value changes.
- On Ruby >= 3.1 the `rb_io_descriptor` branch is compiled, so this build is unaffected; the added tests confirm that path already raises `IOError` for uninitialized and closed streams.
- Verified with libcap-ng 0.9.3 and Ruby 4.0.5 (full suite passes), and the fallback branch was force-compiled with `rb_io_descriptor` undefined to confirm it builds.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
